### PR TITLE
fix: Docker image tags now include v prefix to match release tags (fixes #10)

### DIFF
--- a/.github/workflows/releasebuild.yaml
+++ b/.github/workflows/releasebuild.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
             type=raw,value=latest
 
       - name: Build and push Docker image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+## v1.0.3 (2026-02-28)
+
+### Fixed
+- Fix Docker image tag inconsistency: tags now include the `v` prefix (e.g., `v1.0.3`) to match release tags (fixes [#10](https://github.com/Celedhrim/scantopl/issues/10))
+
 ## v1.0.2 (2026-01-24)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ provide the paperless-ngx url , the paperless-ngx token and the scanservjs outpu
 Have a working go env then
 
 ```
-go install github.com/Celedhrim/scantopl@v1.0.2
+go install github.com/Celedhrim/scantopl@v1.0.3
 ``` 
 
 ### Docker
@@ -51,5 +51,5 @@ $ docker run --rm \
   -v /your/host/scanservjs/output:/output \
   -e PLURL=https://paperless.yourdomain.instance \
   -e PLTOKEN=XXXXXXXXXXXX \
-      ghcr.io/celedhrim/scantopl:v1.0.2
+      ghcr.io/celedhrim/scantopl:v1.0.3
 ```

--- a/scantopl.go
+++ b/scantopl.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	Version = "v1.0.2"
+	Version = "v1.0.3"
 )
 
 func FilenameWithoutExtension(fn string) string {


### PR DESCRIPTION
Bump version to v1.0.3